### PR TITLE
Update subito-searcher.py

### DIFF
--- a/subito-searcher.py
+++ b/subito-searcher.py
@@ -118,7 +118,7 @@ def run_query(url, name, notify):
         title = product.find('h2').string
                 
         try:
-            price=product.find('div',class_=re.compile(r'price')).string
+            price=product.find('p',class_=re.compile(r'price')).string #at the moment (18.3.2021) the price is under the 'p' tag
 
         except:
             price = "Unknown price"


### PR DESCRIPTION
The price parser is not working. I changed 'div' with 'p' because the price is under the 'p' tag.
It seems to work this way.