### PR TITLE
Fix: product list & link finding

### DIFF
--- a/subito-searcher.py
+++ b/subito-searcher.py
@@ -178,7 +178,7 @@ def run_query(url, name, notify, minPrice, maxPrice):
     page = requests.get(url)
     soup = BeautifulSoup(page.text, 'html.parser')
         
-    product_list_items = soup.find_all('div', class_=re.compile(r'item-key-data'))
+    product_list_items = soup.find_all('div', class_=re.compile(r'item-card'))
     msg = []
 
     for product in product_list_items:
@@ -193,7 +193,7 @@ def run_query(url, name, notify, minPrice, maxPrice):
             price = int(price.replace('.','')[:-2])
         except:
             price = "Unknown price"
-        link = product.parent.parent.parent.parent.get('href') 
+        link = product.find('a').get('href')
         try:
             location = product.find('span',re.compile(r'town')).string + product.find('span',re.compile(r'city')).string
         except:


### PR DESCRIPTION
## Issue
As of the current version, the program fails to locate any products upon launch due to a recent update on **Subito.it**. Additionally, the method for extracting links is now obsolete.

## Solution
This PR effectively resolves both of these issues by seamlessly incorporating the essential updates required to adapt to the recent changes.
 - Product List: the website has transitioned from using the `item-key-data` to `item-card` tags for each product
 - Product Link: the link for each product can be found within the first child element of type `a` (anchor), with the value residing in the `href` attribute